### PR TITLE
Create Nested Fields for Tag Creation

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,5 +1,5 @@
 class PostsController < ApplicationController
-  before_action :set_post, only: [:show, :edit, :update, :destroy]
+  before_action :set_post, only: %i[show edit update destroy]
 
   # GET /posts
   # GET /posts.json
@@ -15,6 +15,7 @@ class PostsController < ApplicationController
   # GET /posts/new
   def new
     @post = Post.new
+    @post.tags.build
   end
 
   # GET /posts/1/edit
@@ -61,13 +62,14 @@ class PostsController < ApplicationController
   end
 
   private
-    # Use callbacks to share common setup or constraints between actions.
-    def set_post
-      @post = Post.find(params[:id])
-    end
 
-    # Never trust parameters from the scary internet, only allow the white list through.
-    def post_params
-      params.require(:post).permit(:name, :content, :tag_ids => [])
-    end
+  # Use callbacks to share common setup or constraints between actions.
+  def set_post
+    @post = Post.find(params[:id])
+  end
+
+  # Never trust parameters from the scary internet, only allow the white list through.
+  def post_params
+    params.require(:post).permit(:name, :content, tag_ids: [], tags_attributes: [:name])
+  end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -2,7 +2,8 @@ class Post < ApplicationRecord
   belongs_to :user, optional: true
   has_many :comments
   has_many :post_tags
-  has_many :tags, :through => :post_tags
+  has_many :tags, through: :post_tags
+  accepts_nested_attributes_for :tags, reject_if: proc { |attributes| attributes['name'].blank? }
 
   validates_presence_of :name, :content
 end

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -2,32 +2,31 @@
   <% if @post.errors.any? %>
     <div id="error_explanation">
       <h2><%= pluralize(@post.errors.count, "error") %> prohibited this post from being saved:</h2>
-
       <ul>
-      <% @post.errors.full_messages.each do |msg| %>
-        <li><%= msg %></li>
-      <% end %>
+        <% @post.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+        <% end %>
       </ul>
     </div>
   <% end %>
-
   <div class="field">
     <%= f.label :name %><br>
     <%= f.text_field :name %><br>
     <%= f.label :content %><br>
     <%= f.text_area :content %><br>
   </div>
-
   <div class="field">
-    Tags:
-
-    <%# Add your new tag fields here %>
-
+    <p>Select tags</p>
     <%= f.collection_check_boxes :tag_ids, Tag.all, :id, :name %><br>
   </div>
-
+  <div class="field">
+    <h3>New Tag:</h3>
+    <%= f.fields_for :tags do |tags_form| %>
+      <%= tags_form.label :name %>
+      <%= tags_form.text_field :name %>
+    <% end %>
+  </div>
   <div class="actions">
     <%= f.submit %>
   </div>
-
 <% end %>


### PR DESCRIPTION
This pull request enhances the way tags are managed when creating or editing posts. It introduces support for adding new tags directly within the post form, in addition to selecting existing tags. The changes span the controller, model, and view layers to enable nested tag creation and ensure proper parameter handling.

**Tag Management Improvements**

* Added support for creating new tags alongside posts using nested attributes in the `Post` model (`accepts_nested_attributes_for :tags`), and ensured blank tag names are rejected.
* Updated the `posts_controller` to build a new tag object when initializing a new post, and permitted nested `tags_attributes` in strong parameters. [[1]](diffhunk://#diff-41547fca0ee5b1e4a7a2be25356b71d2fc7389aa1e86fe97fc10cd6f48d1c6dbR18) [[2]](diffhunk://#diff-41547fca0ee5b1e4a7a2be25356b71d2fc7389aa1e86fe97fc10cd6f48d1c6dbR65-R73)

**User Interface Updates**

* Modified the post form (`_form.html.erb`) to allow users to both select existing tags and enter a new tag name directly when creating or editing a post.

**Code Style and Maintenance**

* Cleaned up code style in the controller by using Ruby's preferred `%i[]` array notation for `before_action`.
* Standardized hash syntax in the model for `has_many :tags, through: :post_tags`.